### PR TITLE
Replace rbnacl-libsodium gem dependency with rbnacl

### DIFF
--- a/cryptor.gemspec
+++ b/cryptor.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rbnacl-libsodium'
+  spec.add_development_dependency 'rbnacl'
 end

--- a/lib/cryptor/symmetric_encryption/ciphers/xsalsa20poly1305.rb
+++ b/lib/cryptor/symmetric_encryption/ciphers/xsalsa20poly1305.rb
@@ -1,4 +1,4 @@
-require 'rbnacl/libsodium'
+require 'rbnacl'
 
 require 'cryptor/symmetric_encryption/cipher'
 


### PR DESCRIPTION
This one removes the deprecated `rbnacl-libsodium` gem dependency which includes a binary of the libsodium packaged as part of the gem. It replaces that with `rbnacl` gem. It requires the operating system specific package for `libsodium`. For more information refer to [installing libsodium doc](https://github.com/RubyCrypto/rbnacl/wiki/Installing-libsodium)